### PR TITLE
BUG: Deletion in doubly linked list is not proper. 

### DIFF
--- a/data-structures/doubly-linked-list/doubly-linked-list.js
+++ b/data-structures/doubly-linked-list/doubly-linked-list.js
@@ -162,6 +162,7 @@ DoublyLinkedList.prototype = {
             
                 //skip over the item to remove
                 current.prev.next = current.next;
+                current.next.prev = current.prev;
             }
         
             //decrement the length


### PR DESCRIPTION
While Deleting a node in doubly linked list, you are modifying the "next" pointer of previous node to point to next node of the deleted node, but forgot to modify the "prev" pointer of node following the deleted node. 